### PR TITLE
Track Install Attributed Event

### DIFF
--- a/app/src/main/java/com/segment/analytics/android/integrations/appsflyer/AppsflyerIntegration.java
+++ b/app/src/main/java/com/segment/analytics/android/integrations/appsflyer/AppsflyerIntegration.java
@@ -4,6 +4,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
 
+import com.appsflyer.AppsFlyerConversionListener;
 import com.appsflyer.AppsFlyerLib;
 import com.appsflyer.AppsFlyerProperties;
 import com.segment.analytics.Analytics;
@@ -14,6 +15,7 @@ import com.segment.analytics.integrations.IdentifyPayload;
 import com.segment.analytics.integrations.Integration;
 import com.segment.analytics.integrations.Logger;
 import com.segment.analytics.integrations.TrackPayload;
+import java.util.Map;
 
 /**
  * Created by shacharaharon on 12/04/2016.
@@ -37,6 +39,12 @@ public class AppsflyerIntegration extends Integration<AppsFlyerLib> {
             AppsFlyerLib afLib = AppsFlyerLib.getInstance();
 
             String devKey = settings.getString("devKey");
+            boolean trackAttributionData = settings.getBoolean("trackAttributionData", false);
+            if (trackAttributionData) {
+                AppsFlyerConversionListener listener = new ConversionListener(analytics);
+                Context context = analytics.getApplication();
+                afLib.registerConversionListener(context, listener);
+            }
             return new AppsflyerIntegration(logger, afLib, devKey);
         }
 
@@ -117,6 +125,50 @@ public class AppsflyerIntegration extends Integration<AppsFlyerLib> {
         logger.verbose("appsflyer.trackEvent(null, %s, %s)",context, event, properties);
     }
 
+    static class ConversionListener implements AppsFlyerConversionListener {
+        final Analytics analytics;
+
+        public ConversionListener(Analytics analytics) {
+            this.analytics = analytics;
+        }
+
+        @Override public void onInstallConversionDataLoaded(Map<String, String> conversionData) {
+            trackInstallAttributed(attributionData);
+        }
+
+        @Override public void onInstallConversionFailure(String errorMessage) {
+
+        }
+
+        @Override public void onAppOpenAttribution(Map<String, String> attributionData) {
+            trackInstallAttributed(attributionData);
+        }
+
+        @Override public void onAttributionFailure(String errorMessage) {
+
+        }
+
+        void trackInstallAttributed(Map<String, String> attributionData) {
+            // See https://segment.com/docs/spec/mobile/#install-attributed.
+            Map<String, Object> campaign = new ValueMap() //
+                .putValue("source", attributionData.get("media_source"))
+                .putValue("name", attributionData.get("campaign"))
+                // .putValue("content", attributionData.get("?"))
+                // .putValue("adCreative", attributionData.get("?"))
+                .putValue("adGroup", attributionData.get("adgroup"));
+
+            Properties properties = new Properties() //
+                .putValue("provider", "AppsFlyer")
+                .putValue("campaign", campaign);
+            properties.putAll(attributionData);
+
+            // Remove properties set in campaign.
+            properties.remove("media_source");
+            properties.remove("campaign");
+            properties.remove("adgroup");
+
+            analytics.track("Install Attributed", properties);
+        }
+    }
 
 }
-


### PR DESCRIPTION
This feature will let users record attribution data and send it to Segment as an event, which in turn will also send it to other tools integrated with Segment. 

See https://segment.com/docs/spec/mobile/#install-attributed.